### PR TITLE
Docs: Fetch supporting tools into own sub directory

### DIFF
--- a/scripts/repos-config.json
+++ b/scripts/repos-config.json
@@ -6,7 +6,10 @@
       "github_org": "gardenlinux",
       "github_repo": "gardenlinux",
       "docs_path": "docs",
-      "root_files": ["CONTRIBUTING.md", "SECURITY.md"],
+      "root_files": [
+        "CONTRIBUTING.md",
+        "SECURITY.md"
+      ],
       "target_path": "projects/gardenlinux",
       "branch": "docs-ng",
       "structure": {
@@ -17,7 +20,9 @@
         "contributing": "contributing"
       },
       "special_files": {},
-      "media_directories": [".media"]
+      "media_directories": [
+        ".media"
+      ]
     },
     {
       "name": "builder",
@@ -25,7 +30,6 @@
       "github_org": "gardenlinux",
       "github_repo": "builder",
       "docs_path": "docs",
-      "target_path": "reference/supporting-tools/builder",
       "branch": "docs-ng",
       "structure": "flat"
     },
@@ -35,7 +39,6 @@
       "github_org": "gardenlinux",
       "github_repo": "python-gardenlinux-lib",
       "docs_path": "docs",
-      "target_path": "reference/supporting-tools/python-gardenlinux-lib",
       "branch": "docs-ng",
       "structure": "sphinx"
     }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fetch docs from supporting tools like `builder` or `python-gardenlinux-lib` into their own subsection `Reference > Supporting Tools`.


## Todo:

- [ ] Fix link generation upon aggregation
- [ ] Add documentation to all sections
- [ ] Fix media embedding
- [ ] Fix `make clean` command to remove all directories fetched in `repo-config.json` alongside any cache data

**Which issue(s) this PR fixes**:
Fixes # n/A
