### PR TITLE
Fix: Use absolute paths rather than relative ones to avoid invalid links after transformation

### DIFF
--- a/scripts/transform_content.py
+++ b/scripts/transform_content.py
@@ -511,7 +511,11 @@ def fix_broken_project_links(
         if (
             potential_file.exists()
             or potential_index.exists()
-            or (potential_dir.exists() and potential_dir.is_dir() and (potential_dir / "index.md").exists())
+            or (
+                potential_dir.exists()
+                and potential_dir.is_dir()
+                and (potential_dir / "index.md").exists()
+            )
         ):
             return match.group(0)
 
@@ -660,7 +664,12 @@ def copy_targeted_docs(source_dir, docs_dir, repo_name):
 
             # Check for 'github_target_path' in frontmatter
             if frontmatter and ("github_target_path" in frontmatter):
-                target_path = frontmatter.get("github_target_path") or frontmatter.get("target")
+                target_path = frontmatter.get("github_target_path") or frontmatter.get(
+                    "target"
+                )
+
+                if not target_path:
+                    continue
 
                 # Strip leading 'docs/' if present
                 if target_path.startswith("docs/"):
@@ -671,8 +680,43 @@ def copy_targeted_docs(source_dir, docs_dir, repo_name):
                 # Create parent directories if needed
                 target_file.parent.mkdir(parents=True, exist_ok=True)
 
-                # Copy the file
                 shutil.copy2(md_file, target_file)
+
+                # Copy associated assets directory if it exists
+                source_assets_dir = md_file.parent / "assets"
+                if source_assets_dir.exists() and source_assets_dir.is_dir():
+                    target_assets_dir = target_file.parent / "assets"
+                    if target_assets_dir.exists():
+                        shutil.rmtree(target_assets_dir)
+                    shutil.copytree(source_assets_dir, target_assets_dir)
+
+                # Read content and rewrite asset paths
+                with open(target_file, "r", encoding="utf-8") as f:
+                    content = f.read()
+
+                # Rewrite relative asset paths to absolute paths
+                # Pattern: ![alt](../assets/file.png) or ![alt](./assets/file.png) or ![alt](assets/file.png)
+                import re
+
+                # HACK: Typing error quickfix
+                target_path_str: str = target_path  # type: ignore
+
+                def rewrite_asset_path(match):
+                    alt_text = match.group(1)
+                    path = match.group(2)
+                    # Only rewrite if it's a relative path to assets
+                    if "assets/" in path and not path.startswith("/"):
+                        # Extract just the filename
+                        filename = path.split("assets/")[-1]
+                        # Create absolute path relative to target location
+                        target_path_obj = Path(target_path_str)
+                        abs_path = str(target_path_obj.parent / "assets" / filename)
+                        return f"![{alt_text}](/{abs_path})"
+                    return match.group(0)
+
+                content = re.sub(
+                    r"!\[([^\]]*)\]\(([^)]+)\)", rewrite_asset_path, content
+                )
 
                 # Apply markdown processing (but not project-specific link rewriting)
                 # These files live in main docs tree, not under /projects/


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the way asset/media links are handled. Instead of using relative paths, we try to parse into absolute ones to avoid build failures like this one: https://app.netlify.com/projects/gardenlinux-docs/deploys/69ca6c7386e6990008640519

```
2:28:49 PM: pnpm run docs:build
2:28:49 PM: > @ docs:build /opt/build/repo
2:28:49 PM: > vitepress build docs
2:28:49 PM:   vitepress v1.6.3
2:28:49 PM: - building client + server bundles...
2:28:51 PM: Failed during stage 'building site': Build script returned non-zero exit code: 2 (https://ntl.fyi/exit-code-2)
2:28:51 PM: x Build failed in 958ms
2:28:51 PM: ✖ building client + server bundles...
2:28:51 PM: build error:
2:28:51 PM: Could not resolve "./../assets/first-boot-aws-image.png" from "docs/tutorials/cloud/first-boot-aws.md"
2:28:51 PM: file: /opt/build/repo/docs/tutorials/cloud/first-boot-aws.md
2:28:51 PM: Could not resolve "./../assets/first-boot-aws-image.png" from "docs/tutorials/cloud/first-boot-aws.md"
2:28:51 PM: file: /opt/build/repo/docs/tutorials/cloud/first-boot-aws.md
2:28:51 PM:     at getRollupError (file:///opt/build/repo/node_modules/.pnpm/rollup@4.59.0/node_modules/rollup/dist/es/shared/parseAst.js:402:41)
2:28:51 PM:     at error (file:///opt/build/repo/node_modules/.pnpm/rollup@4.59.0/node_modules/rollup/dist/es/shared/parseAst.js:398:42)
2:28:51 PM:     at ModuleLoader.handleInvalidResolvedId (file:///opt/build/repo/node_modules/.pnpm/rollup@4.59.0/node_modules/rollup/dist/es/shared/node-entry.js:21710:24)
2:28:51 PM:     at file:///opt/build/repo/node_modules/.pnpm/rollup@4.59.0/node_modules/rollup/dist/es/shared/node-entry.js:21670:26
2:28:51 PM:  ELIFECYCLE  Command failed with exit code 1. (https://ntl.fyi/exit-code-1)
2:28:51 PM: make: *** [Makefile:39: build] Error 1
2:28:51 PM: ​
2:28:51 PM: "build.command" failed                                        
2:28:51 PM: ────────────────────────────────────────────────────────────────
2:28:51 PM: ​
2:28:51 PM:   Error message
2:28:51 PM:   Command failed with exit code 2: make build (https://ntl.fyi/exit-code-2)
2:28:51 PM: ​
2:28:51 PM:   Error location
2:28:51 PM:   In Build command from Netlify app:
2:28:51 PM:   make build
2:28:51 PM: ​
2:28:51 PM:   Resolved config
2:28:51 PM:   build:
2:28:51 PM:     command: make build
2:28:51 PM:     commandOrigin: ui
2:28:51 PM:     environment:
2:28:51 PM:       - REVIEW_ID
2:28:51 PM:     publish: /opt/build/repo/docs/.vitepress/dist
2:28:51 PM:     publishOrigin: ui
2:28:51 PM: Build failed due to a user error: Build script returned non-zero exit code: 2
2:28:51 PM: Failing build: Failed to build site
2:28:51 PM: Finished processing build request in 15.323s
```


**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardenlinux/docs-ng/issues/18

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```