### PR TITLE
Fix: Deprecate old target_path specification in repo-config.yml

### DIFF
--- a/scripts/repos-config.json
+++ b/scripts/repos-config.json
@@ -6,20 +6,7 @@
       "github_org": "gardenlinux",
       "github_repo": "gardenlinux",
       "docs_path": "docs",
-      "root_files": [
-        "CONTRIBUTING.md",
-        "SECURITY.md"
-      ],
-      "target_path": "projects/gardenlinux",
       "branch": "docs-ng",
-      "structure": {
-        "tutorials": "tutorials",
-        "how-to": "how-to",
-        "explanation": "explanation",
-        "reference": "reference",
-        "contributing": "contributing"
-      },
-      "special_files": {},
       "media_directories": [
         ".media"
       ]
@@ -31,7 +18,11 @@
       "github_repo": "builder",
       "docs_path": "docs",
       "branch": "docs-ng",
-      "structure": "flat"
+      "media_directories": [
+        ".media",
+        "_static",
+        "assets"
+      ]
     },
     {
       "name": "python-gardenlinux-lib",
@@ -40,7 +31,11 @@
       "github_repo": "python-gardenlinux-lib",
       "docs_path": "docs",
       "branch": "docs-ng",
-      "structure": "sphinx"
+      "media_directories": [
+        ".media",
+        "_static",
+        "assets"
+      ]
     }
   ]
 }

--- a/scripts/transform_content.py
+++ b/scripts/transform_content.py
@@ -629,7 +629,7 @@ def parse_frontmatter(content):
         return None, content
 
 
-def copy_targeted_docs(source_dir, docs_dir, repo_name):
+def copy_targeted_docs(source_dir, docs_dir, repo_name, media_dirs=None):
     """
     Copy markdown files with 'github_target_path:' frontmatter to their specified locations.
 
@@ -637,9 +637,11 @@ def copy_targeted_docs(source_dir, docs_dir, repo_name):
         source_dir: Source directory containing fetched docs (e.g., /tmp/xxx/gardenlinux)
         docs_dir: Target docs directory (e.g., /path/to/docs-ng/docs)
         repo_name: Name of the repository for logging
+        media_dirs: List of media directory names to copy (e.g., ['assets', '_static'])
     """
     source_path = Path(source_dir)
     docs_path = Path(docs_dir)
+    media_dirs = media_dirs or []
 
     if not source_path.exists():
         print(f"  [Warning] Source directory not found: {source_dir}")
@@ -674,6 +676,16 @@ def copy_targeted_docs(source_dir, docs_dir, repo_name):
                 # Copy the file
                 shutil.copy2(md_file, target_file)
 
+                # Copy associated asset directories (assets, _static, .media) if they exist
+                for asset_dir_name in media_dirs:
+                    source_asset_dir = md_file.parent / asset_dir_name
+                    if source_asset_dir.exists() and source_asset_dir.is_dir():
+                        target_asset_dir = target_file.parent / asset_dir_name
+                        if target_asset_dir.exists():
+                            shutil.rmtree(target_asset_dir)
+                        shutil.copytree(source_asset_dir, target_asset_dir)
+                        print(f"      → Copied {asset_dir_name}/ directory")
+
                 # Apply markdown processing (but not project-specific link rewriting)
                 # These files live in main docs tree, not under /projects/
                 # content = escape_angle_brackets(content)
@@ -697,27 +709,17 @@ def copy_targeted_docs(source_dir, docs_dir, repo_name):
 def transform_repo_docs(repo_config, docs_dir, temp_dir):
     """
     Transform documentation for a single repository
+    All files must use 'github_target_path' frontmatter to specify their destination
     """
     repo_name = repo_config["name"]
     print(f"\nTransforming docs for: {repo_name}")
 
     source_dir = os.path.join(temp_dir, repo_name)
-    target_dir = os.path.join(docs_dir, repo_config["target_path"])
-
-    structure = repo_config.get("structure", "flat")
-    special_files = repo_config.get("special_files", {})
     media_dirs = repo_config.get("media_directories", [])
 
-    # First, copy files with 'target:' frontmatter to their specified locations
-    print(f"\n  Step 2a: Processing targeted files...")
-    copy_targeted_docs(source_dir, docs_dir, repo_name)
-
-    # Then, do the standard structure transformation to projects/ directory
-    print(f"\n  Step 2b: Transforming project structure...")
-    transform_directory_structure(
-        source_dir, target_dir, structure, special_files, media_dirs
-    )
-    process_all_markdown(target_dir, repo_name)
+    # Copy files with 'github_target_path' frontmatter to their specified locations
+    print(f"\n  Processing files with github_target_path frontmatter...")
+    copy_targeted_docs(source_dir, docs_dir, repo_name, media_dirs)
 
     print(f"[Complete] Transformation complete for {repo_name}")
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR should fix the current build issue relating to target path mapping for supporting tools. It deprecates the old methods of specifying the output path for aggregated docs, which is now handled by the docs frontmatter. Specifically the `github_target_path` entry of the frontmatter.

```
10:45:44 AM: Transforming docs for: builder
10:45:44 AM: Traceback (most recent call last):
10:45:44 AM:   File "/opt/build/repo/scripts/transform_content.py", line 750, in <module>
10:45:44 AM:     main()
10:45:44 AM:     ~~~~^^
10:45:44 AM:   File "/opt/build/repo/scripts/transform_content.py", line 744, in main
10:45:44 AM:     transform_repo_docs(repo, args.docs_dir, args.temp_dir)
10:45:44 AM:     ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
10:45:44 AM:   File "/opt/build/repo/scripts/transform_content.py", line 705, in transform_repo_docs
10:45:44 AM:     target_dir = os.path.join(docs_dir, repo_config["target_path"])
10:45:44 AM:                                         ~~~~~~~~~~~^^^^^^^^^^^^^^^
10:45:44 AM: KeyError: 'target_path'
10:45:44 AM: Error: Transformation failed
10:45:44 AM: Cleaning up temporary files...
10:45:44 AM: make: *** [Makefile:81: aggregate] Error 1
10:45:44 AM: ​
10:45:44 AM: "build.command" failed                                        
10:45:44 AM: ────────────────────────────────────────────────────────────────
10:45:44 AM: ​
10:45:44 AM:   Error message
10:45:44 AM:   Command failed with exit code 2: make build (https://ntl.fyi/exit-code-2)
10:45:44 AM: ​
10:45:44 AM:   Error location
10:45:44 AM:   In Build command from Netlify app:
10:45:44 AM:   make build
10:45:44 AM: ​
10:45:44 AM:   Resolved config
10:45:44 AM:   build:
10:45:44 AM:     command: make build
10:45:44 AM:     commandOrigin: ui
10:45:44 AM:     environment:
10:45:44 AM:       - REVIEW_ID
10:45:44 AM:     publish: /opt/build/repo/docs/.vitepress/dist
10:45:44 AM:     publishOrigin: ui
10:45:44 AM: Build failed due to a user error: Build script returned non-zero exit code: 2
```

**Which issue(s) this PR fixes**:
Fixes #23 

**Definition of Done:**
- [ ] The code is sufficiently documented
- [ ] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)