### PR TITLE
Add images build docs (simply migrated for now)

### DIFF
--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "4c1d90299cef6cd9db3e800cdd9668949dc8ebec",
+      "commit": "235ee3265e3d7363146769f07b1fab14586eb2aa",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",
@@ -21,7 +21,11 @@
         "reference": "reference",
         "contributing": "contributing"
       },
-      "media_directories": [".media", "assets", "_static"]
+      "media_directories": [
+        ".media",
+        "assets",
+        "_static"
+      ]
     },
     {
       "name": "builder",
@@ -30,7 +34,11 @@
       "target_path": "projects/builder",
       "ref": "docs-ng",
       "commit": "086e74ff032c5f2a05989aef4f20ba69f94bdbf9",
-      "media_directories": [".media", "assets", "_static"]
+      "media_directories": [
+        ".media",
+        "assets",
+        "_static"
+      ]
     },
     {
       "name": "python-gardenlinux-lib",
@@ -40,7 +48,11 @@
       "ref": "docs-ng",
       "commit": "9142fccc3d83ab51759db7d328fa19166bc1df63",
       "structure": "sphinx",
-      "media_directories": [".media", "assets", "_static"]
+      "media_directories": [
+        ".media",
+        "assets",
+        "_static"
+      ]
     },
     {
       "name": "package-linux",
@@ -49,7 +61,11 @@
       "target_path": "projects/package-linux",
       "ref": "docs-ng",
       "commit": "841139441357a222ea10349f6d09a875ce9732d1",
-      "media_directories": [".media", "assets", "_static"]
+      "media_directories": [
+        ".media",
+        "assets",
+        "_static"
+      ]
     },
     {
       "name": "glrd",
@@ -58,7 +74,11 @@
       "target_path": "projects/glrd",
       "ref": "docs-ng",
       "commit": "c444721b728c0be0de2c19a0bc328928a0091d65",
-      "media_directories": [".media", "assets", "_static"]
+      "media_directories": [
+        ".media",
+        "assets",
+        "_static"
+      ]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add images build docs (simply migrated for now).

<img width="1426" height="1938" alt="image" src="https://github.com/user-attachments/assets/8dca1fc3-0d29-4287-933b-55e19a5725f7" />
