### PR TITLE
fix: glrd not under references

### DIFF
--- a/repos-config.json
+++ b/repos-config.json
@@ -73,7 +73,7 @@
       "docs_path": "docs",
       "target_path": "projects/glrd",
       "ref": "docs-ng",
-      "commit": "b855783938aad5cf3238fef9b5dc12190e0b7207",
+      "commit": "b5262e0bf409065ee1b9d62f4d0270695d9081a2",
       "media_directories": [
         ".media",
         "assets",


### PR DESCRIPTION
**What this PR does / why we need it**:

fix: glrd not under references

<img width="1545" height="1979" alt="image" src="https://github.com/user-attachments/assets/e23daee3-e2d3-44e8-bcca-2ddcadac38df" />
