### PR TITLE
Docs: Create Error Reporting Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ docs/how-to/**
 !docs/how-to/documentation/
 !docs/how-to/documentation/**
 !docs/how-to/index.md
+!docs/how-to/reporting-issues.md
 docs/reference/**
 !docs/reference/documentation/
 !docs/reference/documentation/**

--- a/docs/how-to/reporting-issues.md
+++ b/docs/how-to/reporting-issues.md
@@ -1,0 +1,51 @@
+---
+title: Reporting Issues
+description: How to report issues when working with garden linux
+order: 999
+---
+
+# Reporting Issues
+
+In case you encounter any issues in your work with Garden Linux, and the
+information in this documentation cannot help you, please don't hesitate to
+reach out and report your issue.
+
+To do so, first identify which component of the project gives you troubles and
+open a new bug in the appropriate repository:
+
+- [Gardenlinux - The Main Repo](https://github.com/gardenlinux/gardenlinux/issues/new/choose)
+- [Builder](https://github.com/gardenlinux/builder/issues/new/choose)
+- [GLRD - The Garden Linux Release Database](https://github.com/gardenlinux/glrd/issues/new/choose)
+- [Python Library - python-gardenlinux-lib](https://github.com/gardenlinux/python-gardenlinux-lib/issues/new/choose)
+
+In each repository you will find multiple issue types each with their own form.
+Please read these forms carefully and provide as much information as possible
+about your issue.
+
+## Issue Type Not Listed?
+
+For most problems you may encounter, the `bug` issue type might be the best fit
+your report.
+
+However, it is always possible to encounter issues that may not quite fit any of
+the topics.
+
+If the type of issue you face does not have its own form, you can of course just
+open a "Blank Issue". In this case, it is still important for the reviewers of
+your case to know a couple of things:
+
+- What type of issue did you encounter?
+- What area or feature of Garden Linux did the issue show up in?
+- What happened right before the issue occurred (please also provide the exact
+  commands you used)
+- What did you already try to mitigate the issue (if applicable)
+
+If possible, please also attach screenshots or log files to your report.
+
+Remember: _The more information you provide, the quicker reviewers can reproduce
+and analyze the issue._
+
+## Documentation Issue?
+
+Did you find something to improve in this documentation? Please don't hesitate
+to [open a new issue](https://github.com/gardenlinux/docs-ng/issues/new/choose).


### PR DESCRIPTION
**What this PR does / why we need it**:

* Removed guide in gardenlinux repo
* Written guide in reporting-issues.md
* Excluded from .gitignore
* Updated aggregation

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4631

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
