### PR TITLE
docs: update cloud tutorials with pre-built image upload

### DIFF
--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "900bdf88b9e29d97e3a100338fe43be46d333610",
+      "commit": "fd8d380f8ff9423c8ca179fd890ef00a6a4a73a6",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",


### PR DESCRIPTION
**What this PR does / why we need it**:

docs: update cloud tutorials with pre-built image upload

https://github.com/gardenlinux/gardenlinux/commit/fd8d380f8ff9423c8ca179fd890ef00a6a4a73a6

**Which issue(s) this PR fixes**:
Updates https://github.com/gardenlinux/gardenlinux/issues/4595
