### PR TITLE
docs: seperated archived release notes

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -89,9 +89,9 @@ export default defineConfig({
     /\/reference\/index$/,
     /\/contributing\/index$/,
     // Ignore specific release notes pages that don't exist
-    /release-notes\/1592-17/,
-    /release-notes\/1877-11/,
-    /release-notes\/1877-12/,
+    /release-notes\/archived\/1592-17/,
+    /release-notes\/archived\/1877-11/,
+    /release-notes\/archived\/1877-12/,
     // Ignore LICENSE files (e.g. from aggregated repos)
     /LICENSE$/,
     // Ignore broken links inside features for now

--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "fd8d380f8ff9423c8ca179fd890ef00a6a4a73a6",
+      "commit": "b9fd22712f3995b809a17f1ceb2dde6568218008",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",

--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "b9fd22712f3995b809a17f1ceb2dde6568218008",
+      "commit": "fed8c3a16f78e2de04c3aa3b69c97d7704fc19c0",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",

--- a/src/aggregation/glrd.py
+++ b/src/aggregation/glrd.py
@@ -1,0 +1,58 @@
+"""Generate release documentation from GLRD."""
+
+import json
+import subprocess
+import sys
+from typing import Optional
+
+def run_glrd_json(args: list[str]) -> Optional[dict]:
+    """Run glrd command with JSON output and return parsed data."""
+    try:
+        result = subprocess.run(
+            ["glrd"] + args + ["--output-format", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+        print(f"glrd command failed: {result.stderr}", file=sys.stderr)
+        return None
+    except FileNotFoundError:
+        print("glrd not found - install with: pip install glrd", file=sys.stderr)
+        return None
+    except (json.JSONDecodeError, Exception) as e:
+        print(f"Error running glrd: {e}", file=sys.stderr)
+        return None
+
+
+def get_active_minor_versions() -> set[str]:
+    """Get set of active minor release versions from GLRD.
+
+    Returns:
+        Set of version strings (e.g., {"1877.14", "2150.1.0"})
+    """
+    active_versions = set()
+
+    try:
+        result = subprocess.run(
+            ["glrd", "--active", "--type", "minor", "--output-format", "json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            data = json.loads(result.stdout)
+            releases = data.get("releases", [])
+            for release in releases:
+                version_obj = release.get("version", {})
+                if "major" in version_obj and "minor" in version_obj:
+                    if "patch" in version_obj:
+                        version = f"{version_obj['major']}.{version_obj['minor']}.{version_obj['patch']}"
+                    else:
+                        version = f"{version_obj['major']}.{version_obj['minor']}"
+                    active_versions.add(version)
+    except (json.JSONDecodeError, Exception) as e:
+        print(f"Warning: Failed to query active minor versions: {e}", file=sys.stderr)
+
+    return active_versions

--- a/src/aggregation/release_notes.py
+++ b/src/aggregation/release_notes.py
@@ -7,6 +7,10 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from .glrd import (
+    run_glrd_json,
+    get_active_minor_versions
+)
 from .transformer import cleanup_github_markdown
 
 GITHUB_API_URL = "https://api.github.com/repos/gardenlinux/gardenlinux/releases"
@@ -15,6 +19,7 @@ GITHUB_COMMITS_URL = "https://github.com/gardenlinux/gardenlinux/commit"
 
 # Configuration
 MAX_RELEASES = 200  # Include up to 200 recent releases
+ARCHIVED_DIR = "archived"
 
 
 def parse_version(tag: str) -> tuple:
@@ -129,12 +134,27 @@ def generate_release_notes_docs(docs_dir: Path) -> bool:
     releases_dir = docs_dir / "reference" / "releases" / "release-notes"
     releases_dir.mkdir(parents=True, exist_ok=True)
 
+    archived_dir = releases_dir / ARCHIVED_DIR
+    archived_dir.mkdir(parents=True, exist_ok=True)
+
+    # Clean up existing release notes (except index.md and archived/index.md)
+    for md_file in releases_dir.glob("*.md"):
+        if md_file.name not in ["index.md"]:
+            md_file.unlink()
+            print(f"  Removed: {md_file.relative_to(docs_dir)}")
+
     print("Fetching release notes from GitHub...")
     releases = fetch_github_releases()
 
     if not releases:
         print("Warning: No releases fetched from GitHub", file=sys.stderr)
         return False
+
+    # Query GLRD to determine release status
+    print("Querying GLRD for release status...")
+    active_versions = get_active_minor_versions()
+    if not active_versions:
+        print("Warning: GLRD query failed, defaulting all releases to archived", file=sys.stderr)
 
     # Filter releases (skip drafts)
     filtered = []
@@ -161,6 +181,12 @@ def generate_release_notes_docs(docs_dir: Path) -> bool:
         # Make version heading h1 (replace ## VersionName with # VersionName)
         content = re.sub(r'^##\s+' + re.escape(name) + r'$', '# ' + name, content, flags=re.MULTILINE)
 
+        # Determine if this release is archived
+        # A release is active ONLY if it's explicitly in the active_versions dict
+        # All other releases are archived
+        tag_without_v = tag_name.lstrip('v')
+        is_archived = tag_without_v not in active_versions
+
         # Order: highest version = 1, second = 2, etc.
         release_order = idx + 1
 
@@ -168,18 +194,31 @@ def generate_release_notes_docs(docs_dir: Path) -> bool:
 title: "Release {tag_name}"
 description: "Release notes for Garden Linux {tag_name}, published at {date}."
 order: {release_order}
+editLink: false
+related_topics:
+  - /reference/releases/release-lifecycle
+  - /reference/releases/maintained-releases
+  - /reference/releases/archived-releases
+  - /reference/releases/release-notes/
 ---
 
 {content}
 
-## Other Releases
+## Related Topics
 
-- [All Releases Index](../release-notes/index.md)
+<RelatedTopics />
+
 """
 
         # Create filename from tag
         filename = tag_name.replace(".", "-") + ".md"
-        filepath = releases_dir / filename
+
+        # Route to appropriate directory based on archive status
+        if is_archived:
+            filepath = archived_dir / filename
+        else:
+            filepath = releases_dir / filename
+
         filepath.write_text(page_content)
 
         release_list.append({
@@ -187,6 +226,7 @@ order: {release_order}
             "name": name,
             "filename": filename,
             "date": format_release_date(release.get("published_at", "")),
+            "is_archived": is_archived,
         })
         print(f"  Created: {filepath.relative_to(docs_dir)}")
 

--- a/src/aggregation/releases.py
+++ b/src/aggregation/releases.py
@@ -13,34 +13,23 @@ from .constants import (
     LIFECYCLE_LINKS,
 )
 
-
-def run_glrd_json(args: list[str]) -> Optional[dict]:
-    """Run glrd command with JSON output and return parsed data."""
-    try:
-        result = subprocess.run(
-            ["glrd"] + args + ["--output-format", "json"],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if result.returncode == 0:
-            return json.loads(result.stdout)
-        print(f"glrd command failed: {result.stderr}", file=sys.stderr)
-        return None
-    except FileNotFoundError:
-        print("glrd not found - install with: pip install glrd", file=sys.stderr)
-        return None
-    except (json.JSONDecodeError, Exception) as e:
-        print(f"Error running glrd: {e}", file=sys.stderr)
-        return None
+from .glrd import (
+    run_glrd_json,
+    get_active_minor_versions
+)
 
 
-def format_version(release: dict) -> tuple[str, str]:
+def format_version(release: dict, active_versions: set[str]) -> tuple[str, str]:
     """Extract version string and link from release data.
+
+    Args:
+        release: Release data from GLRD
+        active_versions: Set of active minor version strings
 
     Returns:
         Tuple of (version_string, version_link)
-        - Minor releases: link to release notes page
+        - Active minor releases: link to release-notes/{version}.html
+        - Archived minor releases: link to release-notes/archived/{version}.html
         - Major releases: no link (just plain text)
     """
     version_obj = release.get("version", {})
@@ -59,7 +48,13 @@ def format_version(release: dict) -> tuple[str, str]:
 
     # Only link minor releases to release notes; major releases have no link
     if has_minor:
-        version_link = f"[{version_str}](release-notes/{version_str.replace('.', '-')}.html)"
+        # Check if this version is active
+        is_active = version_str in active_versions
+
+        if is_active:
+            version_link = f"[{version_str}](release-notes/{version_str.replace('.', '-')}.html)"
+        else:
+            version_link = f"[{version_str}](release-notes/archived/{version_str.replace('.', '-')}.html)"
     else:
         version_link = version_str  # Major release - no link
 
@@ -146,8 +141,13 @@ gantt
     return gantt
 
 
-def generate_release_table(releases_data: dict) -> str:
-    """Generate markdown table from GLRD JSON data."""
+def generate_release_table(releases_data: dict, active_versions: set[str]) -> str:
+    """Generate markdown table from GLRD JSON data.
+
+    Args:
+        releases_data: Release data from GLRD
+        active_versions: Set of active minor version strings
+    """
     if not releases_data or "releases" not in releases_data:
         return "*No releases found*"
 
@@ -159,7 +159,7 @@ def generate_release_table(releases_data: dict) -> str:
     table += "|:--------|:-------|:---------------------|:---------------------|:-------------------|\n"
 
     for release in releases:
-        _, version_link = format_version(release)
+        _, version_link = format_version(release, active_versions)
         commit_link = format_commit(release)
 
         lifecycle = release.get("lifecycle", {})
@@ -212,6 +212,10 @@ def generate_release_docs(docs_dir: Path) -> bool:
 
     print("Generating release documentation from GLRD...")
 
+    # Get active minor versions for correct link generation
+    active_versions = get_active_minor_versions()
+    print(f"  Found {len(active_versions)} active minor versions")
+
     active_data = run_glrd_json(["--active"])
     archived_data = run_glrd_json(["--archived"])
 
@@ -219,7 +223,7 @@ def generate_release_docs(docs_dir: Path) -> bool:
         print("Warning: Could not fetch active releases - skipping generation", file=sys.stderr)
         return False
 
-    active_table = generate_release_table(active_data)
+    active_table = generate_release_table(active_data, active_versions)
     active_gantt = generate_mermaid_gantt(active_data)
     active_timeline = get_timeline_section(active_gantt, "Release Timeline")
 
@@ -231,11 +235,25 @@ def generate_release_docs(docs_dir: Path) -> bool:
 
     release_file = "maintained-releases.md"
     release_path = (releases_dir / release_file)
-    release_path.write_text(release_path.read_text() + active_content)
+
+    # Read existing file and keep only frontmatter and static content
+    # (everything before the generated tables)
+    existing_content = release_path.read_text()
+    lines = existing_content.split('\n')
+
+    # Find where the generated content starts (look for "## Active Releases" heading)
+    static_lines = []
+    for i, line in enumerate(lines):
+        if line.startswith('## Active Releases') or line.startswith('## Release Timeline'):
+            break
+        static_lines.append(line)
+
+    # Write static content plus new generated content
+    release_path.write_text('\n'.join(static_lines).rstrip() + '\n\n' + active_content)
     print(f"  Updated: {release_path}")
 
     if archived_data is not None:
-        archived_table = generate_release_table(archived_data)
+        archived_table = generate_release_table(archived_data, active_versions)
         archived_gantt = generate_mermaid_gantt(archived_data)
         archived_timeline = get_timeline_section(archived_gantt, "Archived Releases Timeline")
 
@@ -247,7 +265,20 @@ def generate_release_docs(docs_dir: Path) -> bool:
 
         release_file = "archived-releases.md"
         release_path = (releases_dir / release_file)
-        release_path.write_text(release_path.read_text() + archived_content)
+
+        # Read existing file and keep only frontmatter and static content
+        existing_content = release_path.read_text()
+        lines = existing_content.split('\n')
+
+        # Find where the generated content starts (look for "## Out of Maintenance" heading)
+        static_lines = []
+        for i, line in enumerate(lines):
+            if line.startswith('## Out of Maintenance') or line.startswith('## Archived Releases Timeline'):
+                break
+            static_lines.append(line)
+
+        # Write static content plus new generated content
+        release_path.write_text('\n'.join(static_lines).rstrip() + '\n\n' + archived_content)
         print(f"  Updated: {release_path}")
     else:
         print("Warning: Could not fetch archived releases", file=sys.stderr)

--- a/src/aggregation/releases.py
+++ b/src/aggregation/releases.py
@@ -192,46 +192,15 @@ def get_timeline_section(gantt_chart: str, title: str) -> str:
 """
 
 
-def build_release_page(title: str, intro: str, table: str, timeline: str, page_type: str = "maintained") -> str:
-    """Build release page content with frontmatter and sections."""
-    descriptions = {
-        "maintained": "Currently maintained Garden Linux releases with support dates and timelines.",
-        "archived": "Garden Linux releases that have reached end of maintenance and are no longer supported.",
-    }
-    orders = {
-        "maintained": 2,
-        "archived": 3,
-    }
+def append_release_page(table: str, timeline: str, page_type: str = "maintained") -> str:
+    """Append to an existing release page."""
 
-    further_reading = f"""
-
-## Further Reading
-
-- [Release Lifecycle](release-lifecycle.md) — Understanding Garden Linux release phases
-- [Maintained Releases](maintained-releases.md) — Currently supported releases
-- [Archived Releases](archived-releases.md) — Past releases no longer maintained
-- [Release Notes](release-notes/) — Detailed release-specific notes
-"""
-
-    description = descriptions.get(page_type, "")
-    order = orders.get(page_type, 2)
-
-    return f"""---
-title: "{title}"
-description: "{description}"
-order: {order}
----
-
-# {title}
-
-{intro}
-
-:::tip All data is sourced from [GLRD](../../how-to/glrd.html)
-:::
-
+    return f"""
 {table}{timeline}
 
-{further_reading}
+## Related Topics
+
+<RelatedTopics />
 
 """
 
@@ -254,32 +223,32 @@ def generate_release_docs(docs_dir: Path) -> bool:
     active_gantt = generate_mermaid_gantt(active_data)
     active_timeline = get_timeline_section(active_gantt, "Release Timeline")
 
-    active_content = build_release_page(
-        "Maintained Releases",
-        "The table below provides the current list of actively maintained Garden Linux releases. For details about the release lifecycle phases, see [Release Lifecycle](release-lifecycle.md).",
-        f"## Active Releases\n\n{active_table}",
+    active_content = append_release_page(
+        active_table,
         active_timeline,
         "maintained",
     )
 
-    (releases_dir / "maintained-releases.md").write_text(active_content)
-    print(f"  Created: {releases_dir / 'maintained-releases.md'}")
+    release_file = "maintained-releases.md"
+    release_path = (releases_dir / release_file)
+    release_path.write_text(release_path.read_text() + active_content)
+    print(f"  Updated: {release_path}")
 
     if archived_data is not None:
         archived_table = generate_release_table(archived_data)
         archived_gantt = generate_mermaid_gantt(archived_data)
         archived_timeline = get_timeline_section(archived_gantt, "Archived Releases Timeline")
 
-        archived_content = build_release_page(
-            "Archived Releases",
-            "The table below lists releases that have reached their end of maintenance and are no longer actively supported. If you use one of these versions, migrate to the latest maintained release as soon as possible. For details about the release lifecycle, see [Release Lifecycle](release-lifecycle.md).",
-            f"## Out of Maintenance Releases\n\n{archived_table}",
+        archived_content = append_release_page(
+            archived_table,
             archived_timeline,
             "archived",
         )
 
-        (releases_dir / "archived-releases.md").write_text(archived_content)
-        print(f"  Created: {releases_dir / 'archived-releases.md'}")
+        release_file = "archived-releases.md"
+        release_path = (releases_dir / release_file)
+        release_path.write_text(release_path.read_text() + archived_content)
+        print(f"  Updated: {release_path}")
     else:
         print("Warning: Could not fetch archived releases", file=sys.stderr)
 


### PR DESCRIPTION
**What this PR does / why we need it**:

[docs: extend release pages instead of overwriting them](https://github.com/gardenlinux/docs-ng/commit/e35195a78a3615aa4160d154894c12c916c5c7ef)
[docs: seperated archived release notes](https://github.com/gardenlinux/docs-ng/commit/18323ad2bb53ed96345e6d4e4d8a4d6cf0a60545)

<img width="1523" height="1984" alt="image" src="https://github.com/user-attachments/assets/74804760-c33c-4c23-a045-65739ad672e0" />

<img width="1502" height="933" alt="image" src="https://github.com/user-attachments/assets/dd96098d-dffd-49cd-9126-029a7b082df7" />



https://github.com/gardenlinux/gardenlinux/commit/a072dc1ac847419a5a050a50a8387a20598e8c4a

**Which issue(s) this PR fixes**:
Extends https://github.com/gardenlinux/gardenlinux/issues/4594
