### PR TITLE
docs: split builder how-to between vanilla and gardenlinux

### DIFF
--- a/repos-config.json
+++ b/repos-config.json
@@ -33,7 +33,7 @@
       "docs_path": "docs",
       "target_path": "projects/builder",
       "ref": "docs-ng",
-      "commit": "7a7c3430ba21794d7f30876df8850e1424768149",
+      "commit": "fb9760c0f762c2209fdf23c88c251351d255d2a5",
       "media_directories": [
         ".media",
         "assets",


### PR DESCRIPTION
**What this PR does / why we need it**:

docs: split builder how-to between vanilla and gardenlinux

https://github.com/gardenlinux/builder/commit/788a3729ca2f05a04868a3f38aeaa8eb70d428cb

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4628
