### PR TITLE
docs: update and restructure container-base-image

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -88,7 +88,7 @@ for precise technical details.
 **Start here**: [Reference](/reference/)
 
 Includes the [flavor matrix](/reference/flavor-matrix),
-[glossary](/reference/glossary), [kernel](/reference/kernel),
+[glossary](/reference/glossary), [kernel](/reference/kernel-builds.md),
 [release information](/reference/releases/), Architecture Decision Records
 (ADRs) in the [ADR catalog](/reference/adr/), and
 [supporting tools documentation](/reference/supporting_tools/) (builder, Python

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -211,7 +211,7 @@ Automated builds of Garden Linux that occur on a regular schedule from the lates
 
 ### OCI (OCI Image Format)
 
-OCI Image Format. A container image specification defined by the Open Container Initiative. Garden Linux provides OCI-formatted container images. See [First Boot as OCI image](../tutorials/container/first-boot-oci.md) and the [OCI platform guide](../how-to/installation/container/oci.md) for usage details.
+OCI Image Format. A container image specification defined by the Open Container Initiative. Garden Linux provides OCI-formatted container images. See [First Boot as OCI image](../tutorials/container/first-boot-oci.md) and the [OCI platform guide](../how-to/installation/container/index.md) for usage details.
 
 ### OpenSSL
 

--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "c1d1be1f4d0fc2a3dc3a9adba110afac93a1f980",
+      "commit": "a6251a94a3e75d13f3a22ce826a2760b69165b94",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",

--- a/repos-config.json
+++ b/repos-config.json
@@ -6,7 +6,7 @@
       "docs_path": "docs",
       "target_path": "projects/gardenlinux",
       "ref": "docs-ng",
-      "commit": "a27f522ddddc5c2f61dbec6e5bc831a713fe076c",
+      "commit": "c1d1be1f4d0fc2a3dc3a9adba110afac93a1f980",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",


### PR DESCRIPTION
**What this PR does / why we need it**:
[docs: update and restructure container-base-image](https://github.com/gardenlinux/docs-ng/commit/0565b1b452ec3341e1180d19ab16b3557d06b133)

https://github.com/gardenlinux/gardenlinux/pull/4707

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4626
