### PR TITLE
docs: move kernel docs to package-linux and restructure

### DIFF
--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -88,7 +88,7 @@ for precise technical details.
 **Start here**: [Reference](/reference/)
 
 Includes the [flavor matrix](/reference/flavor-matrix),
-[glossary](/reference/glossary), [kernel](/reference/kernel-builds.md),
+[glossary](/reference/glossary), [kernel flavors](/reference/kernel-flavors),
 [release information](/reference/releases/), Architecture Decision Records
 (ADRs) in the [ADR catalog](/reference/adr/), and
 [supporting tools documentation](/reference/supporting_tools/) (builder, Python

--- a/repos-config.json
+++ b/repos-config.json
@@ -60,7 +60,7 @@
       "docs_path": "docs",
       "target_path": "projects/package-linux",
       "ref": "docs-ng",
-      "commit": "efd3f4ec64b01d5b7b76fd0e51ace99d4b9fc582",
+      "commit": "057e2cef82be30255ed68281ffd0452cfc1cb76c",
       "media_directories": [
         ".media",
         "assets",


### PR DESCRIPTION
**What this PR does / why we need it**:

[docs: move kernel docs to package-linux and restructure](https://github.com/gardenlinux/docs-ng/commit/77e1f1fb1e5d350eda751c34f644971ad2f00663)

https://github.com/gardenlinux/package-linux/pull/288

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4629
