### PR TITLE
Feat/reusable ci workflows

### DIFF
--- a/.github/workflows/check-pr-main.yml
+++ b/.github/workflows/check-pr-main.yml
@@ -20,21 +20,22 @@ jobs:
           script: |
             const fs = require('fs');
             const config = JSON.parse(fs.readFileSync('repos-config.json', 'utf8'));
-            const ALLOWED_REFS = new Set(['main', 'master']);
+            const ALLOWED_REFS = new Set(['main', 'docs-ng']);
 
             const errors = [];
             for (const repo of config.repos) {
               const ref = repo.ref || '';
-              if (!ALLOWED_REFS.has(ref) && !ref.startsWith('v') && !ref.startsWith('release-')) {
-                errors.push(`  - ${repo.name}: ref='${ref}' (expected 'main' or a tag)`);
+              const semverRegex = /^\d+\.\d+\.\d+$/;
+              if (!ALLOWED_REFS.has(ref) && !semverRegex.test(ref)) {
+                errors.push(`  - ${repo.name}: ref='${ref}' (expected 'main' or a release version)`);
               }
             }
 
             if (errors.length > 0) {
               core.setFailed(
-                `repos-config.json contains non-main branch references:\n${errors.join('\n')}\n\n` +
-                `PRs cannot be merged until all repos reference main branches or tags.`
+                `repos-config.json contains non-main branch or non release version references:\n${errors.join('\n')}\n\n` +
+                `PRs cannot be merged until all repos reference main branches or release versions.`
               );
             } else {
-              core.info('All repos reference main branches or tags');
+              core.info('All repos reference main branches or release versions');
             }

--- a/.github/workflows/check-pr-main.yml
+++ b/.github/workflows/check-pr-main.yml
@@ -3,8 +3,6 @@ name: Validate repos-config.json
 on:
   pull_request:
     branches: [main]
-    paths:
-      - 'repos-config.json'
 
 jobs:
   validate:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -90,8 +90,8 @@ jobs:
             for (const repo of config.repos) {
               if (repo.name === repoName) {
                 repo.commit = commitSha;
-                // If merged, update ref to main; otherwise keep PR branch
-                repo.ref = event === 'merged' ? 'main' : ref;
+                // Always use the ref from the payload (for merged PRs, this is the base branch)
+                repo.ref = ref;
                 break;
               }
             }
@@ -131,7 +131,7 @@ jobs:
             if (existingPRs.length > 0) {
               const existingPR = existingPRs[0];
               core.info(`PR #${existingPR.number} already exists, updating...`);
-              
+
               // If merged, mark PR as ready (remove draft status)
               if (event === 'merged') {
                 await github.rest.pulls.update({
@@ -146,7 +146,7 @@ jobs:
             } else {
               core.info('Creating new draft PR...');
               const statusText = event === 'merged' ? 'Ready for review' : 'Draft (waiting for source PR to merge)';
-              
+
               const { data: newPR } = await github.rest.pulls.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,


### PR DESCRIPTION
**What this PR does / why we need it**:

- [fix: repos-config.json may contain, main, docs-ng or release version ref](https://github.com/gardenlinux/docs-ng/commit/bececf327aba008894b1d46fab0632a1fee53b6a)
- [fix: Always use the ref from the payload](https://github.com/gardenlinux/docs-ng/commit/bc9eb117665f9304268d0b24c428063f95bef160)
- [fix: always run repos-config.json validation for PRs to main](https://github.com/gardenlinux/docs-ng/pull/78/commits/c9e50330b6cadc1886ffc7cc1ad8cb4fb3c3a63d)
