### PR TITLE
feat: Sidebar: Add indentation for children of level-0 (2nd level items)

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -90,6 +90,12 @@ img[src="/search.png"] {
   padding-bottom: 10px;
 }
 
+/* Sidebar: Add indentation for children of level-0 (2nd level items) */
+#VPSidebarNav .VPSidebarItem.level-0 > .items {
+  padding-left: 16px;
+  border-left: 1px solid var(--vp-c-divider);
+}
+
 /* GitHub social link styling */
 .VPSocialLink[href*="github"] {
   color: var(--vp-c-text-1);


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: Sidebar: Add indentation for children of level-0 (2nd level items)


### before

<img width="241" height="444" alt="Image" src="https://github.com/user-attachments/assets/894768b0-958e-4402-84de-9825490e640d" />

### after

<img width="245" height="459" alt="Image" src="https://github.com/user-attachments/assets/905d6026-105a-42ed-8544-a86fd96f4a24" />

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4898
