### PR TITLE
fix: ci: use aggregated docs for vitepress build

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -148,11 +148,18 @@ jobs:
           make woke
 
   build:
+    needs: aggregate
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: gardenlinux/docs-ng
+
+      - name: Download aggregated docs
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: aggregated-docs
+          path: docs/
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
 
@@ -162,16 +169,10 @@ jobs:
           node-version: "22"
           cache: "pnpm"
 
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # pin@v6.2.0
-        with:
-          python-version: "3.13"
-
       - name: Install dependencies
         run: |
           pnpm install
-          pip install -r requirements.txt
 
       - name: Run Vitepress Build
         run: |
-          make build
+          pnpm run docs:build

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -37,7 +37,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.DOCS_BOT_APP_ID }}
+          client-id: ${{ secrets.DOCS_BOT_APP_ID }}
           private-key: ${{ secrets.DOCS_BOT_PRIVATE_KEY }}
           repositories: docs-ng,${{ github.event.client_payload.repo || inputs.repo }}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
[fix: ci: use aggregated docs for vitepress build](https://github.com/gardenlinux/docs-ng/commit/7f30c6b715815b9b013a63bb25377a058221d5e9)
