### PR TITLE
Fix: Fix run makefile target being called "dev"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help run dev build preview aggregate aggregate-repo test-aggregate-local clean clean-projects clean-aggregated-git test test-unit test-integration check spelling linkcheck woke
+.PHONY: help run build preview aggregate aggregate-repo test-aggregate-local clean clean-projects clean-aggregated-git test test-unit test-integration check spelling linkcheck woke
 
 help:
 	@echo "Garden Linux Documentation Hub - Available targets:"
@@ -37,7 +37,7 @@ install:
 	pip install git+https://github.com/gardenlinux/python-gardenlinux-lib.git@0.10.20
 	pip install -r requirements.txt
 
-dev:
+run:
 	pnpm run docs:dev
 
 build: install clean aggregate

--- a/docs/contributing/documentation/working-locally.md
+++ b/docs/contributing/documentation/working-locally.md
@@ -75,7 +75,7 @@ This copies documentation from local repositories without using git.
 ### Step 4: Start the Development Server
 
 ```bash
-make dev
+make run
 ```
 
 The documentation site will be available at `http://localhost:5173`.
@@ -146,7 +146,7 @@ If you encounter issues, try a clean build:
 ```bash
 make clean
 make aggregate
-make dev
+make run
 ```
 
 ### Check Dependencies

--- a/src/aggregate.py
+++ b/src/aggregate.py
@@ -273,7 +273,7 @@ Examples:
 
     print("\nNext steps:")
     print("  1. Review the changes in docs/projects/")
-    print("  2. Run 'make dev' or 'pnpm run docs:dev' to preview")
+    print("  2. Run 'make run' or 'pnpm run docs:dev' to preview")
     print("  3. Commit the changes if satisfied")
 
     return 0 if fail_count == 0 else 1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the name mismatch between the old `run` make target and the `dev` target by renaming `dev` back to `run`.

**Which issue(s) this PR fixes**:
Fixes: n/A

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)
