### PR TITLE
ci(fix)): bump the lychee version to correctly not cache errors

### DIFF
--- a/.github/workflows/docs-checks.yml
+++ b/.github/workflows/docs-checks.yml
@@ -84,8 +84,9 @@ jobs:
 
       # installing lychee to call it via make target is hard
       - name: Run link check
-        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # unreleased
         with:
+          lycheeVersion: v0.24.2
           args: --cache --max-cache-age 1d docs/**/*.md --config lychee.toml --root-dir "$(pwd)/docs/"
 
       - name: Save lychee cache


### PR DESCRIPTION
**What this PR does / why we need it**:

ci(fix)): bump the lychee version to correctly not cache errors
