### PR TITLE
 docs: add mermaid-classdefs plugin and migrate contributing diagrams, dark and light mode images

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -3,6 +3,7 @@ import matter from "gray-matter";
 import { join } from "path";
 import { defineConfig } from "vitepress";
 import { generateDocumentationSidebar } from "./sidebar.js";
+import { mermaidClassDefs } from "./plugins/mermaid-classdefs.js";
 
 // Get base URL from environment variable (for GitHub Pages deployment)
 const base = process.env.BASE_URL || "/";
@@ -76,6 +77,9 @@ function normalizeUrl(ref: string): string {
 export default defineConfig({
   base,
   title: "Garden Linux",
+  markdown: {
+    config: (md) => md.use(mermaidClassDefs),
+  },
   // description: "Operating system built for cloud native workloads.",
   ignoreDeadLinks: [
     // Ignore dead links in legacy documentation

--- a/docs/.vitepress/plugins/mermaid-classdefs.ts
+++ b/docs/.vitepress/plugins/mermaid-classdefs.ts
@@ -1,0 +1,63 @@
+import type MarkdownIt from 'markdown-it'
+
+/**
+ * Shared classDef preamble injected into flowchart/graph mermaid fence blocks.
+ *
+ * Five canonical semantic categories:
+ *   decision – conditional branches, diamond nodes      (blue)
+ *   input    – triggers, external sources               (yellow/amber)
+ *   process  – intermediate work, retries               (gray)
+ *   output   – successful terminal, published artefacts (green)
+ *   neutral  – sequential steps with no special role    (violet)
+ *
+ * Authors use `class NodeA,NodeB neutral` in their diagrams and never
+ * write hex color codes directly. All color definitions live here.
+ */
+const CLASSDEFS_PREAMBLE =
+    '    classDef decision fill:#e1f5ff,stroke:#3b82f6,color:#0b1e3a;\n' +
+    '    classDef input    fill:#fff4e1,stroke:#d97706,color:#3a2408;\n' +
+    '    classDef process  fill:#f0f0f0,stroke:#6b7280,color:#111827;\n' +
+    '    classDef output   fill:#d4edda,stroke:#16a34a,color:#0b2e13;\n' +
+    '    classDef neutral  fill:#f0e6ff,stroke:#7c3aed,color:#1e0a3c;\n'
+
+/**
+ * markdown-it plugin that injects shared mermaid classDef declarations
+ * into every fenced flowchart/graph code block, inserted after the
+ * diagram-type declaration line.
+ *
+ * Only `flowchart` and `graph` diagram types are modified; other types
+ * (`sequenceDiagram`, `gantt`, `%%{init}%%`, etc.) are left untouched
+ * because `classDef` is not valid syntax for those diagram types.
+ *
+ * Registration in VitePress config.mts:
+ *
+ *   import { mermaidClassDefs } from './plugins/mermaid-classdefs.js'
+ *
+ *   export default defineConfig({
+ *     markdown: {
+ *       config: (md) => md.use(mermaidClassDefs),
+ *     },
+ *   })
+ */
+export function mermaidClassDefs(md: MarkdownIt): void {
+    // Must register after 'block' — that is the rule which parses fence tokens.
+    // Registering after 'normalize' fires too early (tokens are empty at that point).
+    md.core.ruler.after('block', 'mermaid-classdefs', (state) => {
+        for (const token of state.tokens) {
+            if (token.type !== 'fence') continue
+            if (token.info.trim() !== 'mermaid') continue
+
+            // Only inject into flowchart/graph diagrams; classDef is not
+            // valid in sequenceDiagram, gantt, %%{init}%% blocks, etc.
+            const firstLine = token.content.split('\n')[0].trim().toLowerCase()
+            if (!firstLine.startsWith('flowchart') && !firstLine.startsWith('graph ')) continue
+
+            // Insert preamble after the diagram-type declaration line so
+            // the diagram-type keyword remains first (required by mermaid).
+            const nl = token.content.indexOf('\n')
+            token.content = nl === -1
+                ? token.content + '\n' + CLASSDEFS_PREAMBLE
+                : token.content.slice(0, nl + 1) + CLASSDEFS_PREAMBLE + token.content.slice(nl + 1)
+        }
+    })
+}

--- a/docs/.vitepress/plugins/mermaid-classdefs.ts
+++ b/docs/.vitepress/plugins/mermaid-classdefs.ts
@@ -4,21 +4,31 @@ import type MarkdownIt from 'markdown-it'
  * Shared classDef preamble injected into flowchart/graph mermaid fence blocks.
  *
  * Five canonical semantic categories:
- *   decision – conditional branches, diamond nodes      (blue)
- *   input    – triggers, external sources               (yellow/amber)
- *   process  – intermediate work, retries               (gray)
- *   output   – successful terminal, published artefacts (green)
- *   neutral  – sequential steps with no special role    (violet)
+ *   decision – conditional branches, diamond nodes
+ *   input    – triggers, external sources
+ *   process  – intermediate work, retries
+ *   output   – successful terminal, published artefacts
+ *   neutral  – sequential steps with no special role
  *
  * Authors use `class NodeA,NodeB neutral` in their diagrams and never
- * write hex color codes directly. All color definitions live here.
+ * write hex color codes directly.
+ *
+ * Colors (both light-mode and dark-mode palettes) are defined in
+ * docs/.vitepress/theme/style.css under the "Mermaid canonical classes"
+ * section. The classDef lines below use only opacity:1 (a visually inert
+ * no-op) so that mermaid does NOT emit fill/stroke/color/stroke-width
+ * !important rules from classDef. The class name itself is what matters:
+ * mermaid attaches the class name to the node's <g> element, and the
+ * external CSS uses !important to beat the theme's SVG-scoped id-selector
+ * rules (e.g. "#mermaid-123 .node rect { fill: ... }") that would otherwise
+ * take precedence over plain class selectors.
  */
 const CLASSDEFS_PREAMBLE =
-    '    classDef decision fill:#e1f5ff,stroke:#3b82f6,color:#0b1e3a;\n' +
-    '    classDef input    fill:#fff4e1,stroke:#d97706,color:#3a2408;\n' +
-    '    classDef process  fill:#f0f0f0,stroke:#6b7280,color:#111827;\n' +
-    '    classDef output   fill:#d4edda,stroke:#16a34a,color:#0b2e13;\n' +
-    '    classDef neutral  fill:#f0e6ff,stroke:#7c3aed,color:#1e0a3c;\n'
+    '    classDef decision opacity:1;\n' +
+    '    classDef input    opacity:1;\n' +
+    '    classDef process  opacity:1;\n' +
+    '    classDef output   opacity:1;\n' +
+    '    classDef neutral  opacity:1;\n'
 
 /**
  * markdown-it plugin that injects shared mermaid classDef declarations

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -16,7 +16,7 @@ export default {
 
     const initMermaid = () => {
       createMermaidRenderer({
-        // Use base theme; colors are set inline per diagram
+        // Colors are injected globally via the mermaid-classdefs markdown plugin
         theme: isDark.value ? 'dark' : 'default',
       })
     }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -146,3 +146,183 @@ img[src="/search.png"] {
 :root:not(.dark) [src$="#dark-mode-only"] {
   display: none;
 }
+
+/*
+ * Mermaid canonical class colors (light and dark mode)
+ *
+ * The five semantic classes (decision, input, process, output, neutral) are
+ * injected into every flowchart/graph fence by the mermaid-classdefs plugin
+ * (docs/.vitepress/plugins/mermaid-classdefs.ts). That plugin emits only a
+ * stroke-width sentinel so mermaid does NOT emit fill/stroke/color !important
+ * rules for these classes.
+ *
+ * However, mermaid's theme CSS is scoped to the SVG's id (e.g.
+ * "#mermaid-123 .node rect { fill: ... }"), giving it higher specificity than
+ * plain class selectors. !important is therefore required here to override the
+ * theme's node fill/stroke defaults.
+ *
+ * Node shapes: rect, polygon (diamond), circle, ellipse, path (stadium/rounded).
+ * Text: htmlLabels mode wraps text in foreignObject; tspan covers non-html mode.
+ */
+
+/* --- Light mode --- */
+.mermaid .decision > rect,
+.mermaid .decision > polygon,
+.mermaid .decision > circle,
+.mermaid .decision > ellipse,
+.mermaid .decision > path {
+  fill: #e1f5ff !important;
+  stroke: #3b82f6 !important;
+}
+.mermaid .decision foreignObject div,
+.mermaid .decision foreignObject p,
+.mermaid .decision foreignObject span,
+.mermaid .decision tspan {
+  color: #0b1e3a !important;
+  fill: #0b1e3a !important;
+}
+
+.mermaid .input > rect,
+.mermaid .input > polygon,
+.mermaid .input > circle,
+.mermaid .input > ellipse,
+.mermaid .input > path {
+  fill: #fff4e1 !important;
+  stroke: #d97706 !important;
+}
+.mermaid .input foreignObject div,
+.mermaid .input foreignObject p,
+.mermaid .input foreignObject span,
+.mermaid .input tspan {
+  color: #3a2408 !important;
+  fill: #3a2408 !important;
+}
+
+.mermaid .process > rect,
+.mermaid .process > polygon,
+.mermaid .process > circle,
+.mermaid .process > ellipse,
+.mermaid .process > path {
+  fill: #f0f0f0 !important;
+  stroke: #6b7280 !important;
+}
+.mermaid .process foreignObject div,
+.mermaid .process foreignObject p,
+.mermaid .process foreignObject span,
+.mermaid .process tspan {
+  color: #111827 !important;
+  fill: #111827 !important;
+}
+
+.mermaid .output > rect,
+.mermaid .output > polygon,
+.mermaid .output > circle,
+.mermaid .output > ellipse,
+.mermaid .output > path {
+  fill: #d4edda !important;
+  stroke: #16a34a !important;
+}
+.mermaid .output foreignObject div,
+.mermaid .output foreignObject p,
+.mermaid .output foreignObject span,
+.mermaid .output tspan {
+  color: #0b2e13 !important;
+  fill: #0b2e13 !important;
+}
+
+.mermaid .neutral > rect,
+.mermaid .neutral > polygon,
+.mermaid .neutral > circle,
+.mermaid .neutral > ellipse,
+.mermaid .neutral > path {
+  fill: #f0e6ff !important;
+  stroke: #7c3aed !important;
+}
+.mermaid .neutral foreignObject div,
+.mermaid .neutral foreignObject p,
+.mermaid .neutral foreignObject span,
+.mermaid .neutral tspan {
+  color: #1e0a3c !important;
+  fill: #1e0a3c !important;
+}
+
+/* --- Dark mode --- */
+:root.dark .mermaid .decision > rect,
+:root.dark .mermaid .decision > polygon,
+:root.dark .mermaid .decision > circle,
+:root.dark .mermaid .decision > ellipse,
+:root.dark .mermaid .decision > path {
+  fill: #0b1e3a !important;
+  stroke: #60a5fa !important;
+}
+:root.dark .mermaid .decision foreignObject div,
+:root.dark .mermaid .decision foreignObject p,
+:root.dark .mermaid .decision foreignObject span,
+:root.dark .mermaid .decision tspan {
+  color: #dbeafe !important;
+  fill: #dbeafe !important;
+}
+
+:root.dark .mermaid .input > rect,
+:root.dark .mermaid .input > polygon,
+:root.dark .mermaid .input > circle,
+:root.dark .mermaid .input > ellipse,
+:root.dark .mermaid .input > path {
+  fill: #3a2408 !important;
+  stroke: #fbbf24 !important;
+}
+:root.dark .mermaid .input foreignObject div,
+:root.dark .mermaid .input foreignObject p,
+:root.dark .mermaid .input foreignObject span,
+:root.dark .mermaid .input tspan {
+  color: #fef3c7 !important;
+  fill: #fef3c7 !important;
+}
+
+:root.dark .mermaid .process > rect,
+:root.dark .mermaid .process > polygon,
+:root.dark .mermaid .process > circle,
+:root.dark .mermaid .process > ellipse,
+:root.dark .mermaid .process > path {
+  fill: #1f2937 !important;
+  stroke: #9ca3af !important;
+}
+:root.dark .mermaid .process foreignObject div,
+:root.dark .mermaid .process foreignObject p,
+:root.dark .mermaid .process foreignObject span,
+:root.dark .mermaid .process tspan {
+  color: #f3f4f6 !important;
+  fill: #f3f4f6 !important;
+}
+
+:root.dark .mermaid .output > rect,
+:root.dark .mermaid .output > polygon,
+:root.dark .mermaid .output > circle,
+:root.dark .mermaid .output > ellipse,
+:root.dark .mermaid .output > path {
+  fill: #0b2e13 !important;
+  stroke: #4ade80 !important;
+}
+:root.dark .mermaid .output foreignObject div,
+:root.dark .mermaid .output foreignObject p,
+:root.dark .mermaid .output foreignObject span,
+:root.dark .mermaid .output tspan {
+  color: #d1fae5 !important;
+  fill: #d1fae5 !important;
+}
+
+:root.dark .mermaid .neutral > rect,
+:root.dark .mermaid .neutral > polygon,
+:root.dark .mermaid .neutral > circle,
+:root.dark .mermaid .neutral > ellipse,
+:root.dark .mermaid .neutral > path {
+  fill: #1e0a3c !important;
+  stroke: #a78bfa !important;
+}
+:root.dark .mermaid .neutral foreignObject div,
+:root.dark .mermaid .neutral foreignObject p,
+:root.dark .mermaid .neutral foreignObject span,
+:root.dark .mermaid .neutral tspan {
+  color: #ede9fe !important;
+  fill: #ede9fe !important;
+}

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -137,3 +137,12 @@ img[src="/search.png"] {
     padding: 18px 12px;
   }
 }
+
+/* select based on dark or light mode */
+:root.dark [src$="#light-mode-only"] {
+  display: none;
+}
+
+:root:not(.dark) [src$="#dark-mode-only"] {
+  display: none;
+}

--- a/docs/contributing/documentation/aggregation-architecture.md
+++ b/docs/contributing/documentation/aggregation-architecture.md
@@ -25,41 +25,62 @@ system.
 We use a documentation aggregation pipeline that combines content from multiple
 source repositories into a unified VitePress documentation site.
 
-```
-┌─────────────────┐
-│ Source Repos    │
-│ - gardenlinux   │
-│ - builder       │
-│ - python-gl-lib │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ Fetch Stage     │
-│ Git sparse      │
-│ checkout or     │
-│ local copy      │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ Transform Stage │
-│ Rewrite links   │
-│ Fix front-matter│
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ Structure Stage │
-│ Reorganize dirs │
-│ Copy media      │
-└────────┬────────┘
-         │
-         ▼
-┌─────────────────┐
-│ docs/ output    │
-│ VitePress build │
-└─────────────────┘
+```mermaid
+flowchart TD
+    subgraph Sources
+        SR[Source Repos]
+        GRA[GitHub Releases API]
+        GL[GLRD]
+        FY[flavors.yaml]
+    end
+
+    subgraph Fetch
+        DF["DocsFetcher\n(git sparse / local)"]
+        GH["github_api.list_repo_releases()"]
+        GD["glrd.run_glrd_json()"]
+    end
+
+    subgraph OptionalPreTransform["Optional Pre-Transform"]
+        SB["sphinx_builder.build_sphinx_markdown()\n(repos with structure: sphinx only)"]
+    end
+
+    subgraph Transform
+        TR[transformer.py]
+    end
+
+    subgraph Structure
+        ST[structure.py]
+    end
+
+    subgraph Generators
+        RL[releases.py]
+        RN[release_notes.py]
+        FM[flavor_matrix.py]
+    end
+
+    OUT[docs/]
+
+    SR --> DF
+    GRA --> GH
+    GL --> GD
+    FY --> FM
+
+    DF --> SB
+    SB --> TR
+    DF --> TR
+    TR --> ST
+    ST --> OUT
+
+    GH --> RL
+    GH --> RN
+    GD --> RL
+    RL --> OUT
+    RN --> OUT
+    FM --> OUT
+
+    class SR,GRA,GL,FY input
+    class DF,GH,GD,SB,TR,ST,RL,RN,FM process
+    class OUT output
 ```
 
 ## Core Components

--- a/docs/contributing/documentation/ci-architecture.md
+++ b/docs/contributing/documentation/ci-architecture.md
@@ -122,6 +122,12 @@ flowchart TD
     S --> T[Published site updated]
 
     P -->|no, more commits| A
+
+    class A,S input
+    class B,C,D,E,F,G,H,I,J,K,Q,R process
+    class P decision
+    class L,M,N,O process
+    class T output
 ```
 
 ## CI Flow Scenarios

--- a/docs/contributing/documentation/ci-workflows-reference.md
+++ b/docs/contributing/documentation/ci-workflows-reference.md
@@ -100,6 +100,12 @@ flowchart TD
     B -->|yes, merged| D
     B -->|yes, not merged| E["workflow ends<br/>(no action)"]
     D --> F["repository_dispatch → docs-ng<br/>event_type: docs-pr"]
+
+    class A input
+    class C,D process
+    class B decision
+    class E process
+    class F output
 ```
 
 ### Common Failure Causes
@@ -193,6 +199,10 @@ flowchart TD
     C --> E["spelling job<br/>(make spelling / codespell)"]
     C --> F["woke job<br/>(make woke)"]
     D & E & F --> G["All checks pass ✓"]
+
+    class A input
+    class B,C,D,E,F process
+    class G output
 ```
 
 ### Common Failure Causes
@@ -308,6 +318,11 @@ flowchart TD
     H -->|yes| I["Update existing PR<br/>(draft status based on event)"]
     H -->|no| J["Create new draft PR"]
     I & J --> K["Post/update comment<br/>on source-repo PR"]
+
+    class A input
+    class B,C,D,E,F,G,I,J process
+    class H decision
+    class K output
 ```
 
 ### Common Failure Causes
@@ -383,6 +398,12 @@ flowchart TD
     C --> D{"For each repo:<br/>ref ∈ {main, docs-ng, semver}?"}
     D -->|all valid| E["✓ Check passes"]
     D -->|invalid refs found| F["✗ Check fails<br/>lists non-compliant repos"]
+
+    class A input
+    class B,C process
+    class D decision
+    class E output
+    class F process
 ```
 
 ### Common Failure Causes

--- a/docs/contributing/documentation/vitepress-features.md
+++ b/docs/contributing/documentation/vitepress-features.md
@@ -133,7 +133,7 @@ Garden Linux documentation supports [Mermaid](https://mermaid.js.org/) diagrams 
 - Displaying complex relationships
 
 **How it works:**
-The plugin automatically renders code blocks marked with `mermaid` as diagrams. It supports dark mode and injects a shared set of semantic class definitions into every diagram at build time.
+The plugin automatically renders code blocks marked with `mermaid` as diagrams. It injects a shared set of semantic class definitions into every diagram at build time and supports both light and dark mode — node colors switch automatically when the reader toggles the theme.
 
 **Syntax:**
 
@@ -163,15 +163,15 @@ gantt
 
 ### Mermaid styling
 
-Flowchart nodes are styled using five canonical semantic class names. The VitePress build injects their color definitions automatically — **do not write `classDef` or `style X fill:` lines in diagram source**. Use only `class` assignment statements. Every node must be assigned one of these five classes.
+Flowchart nodes are styled using five canonical semantic class names. Color values for both light mode and dark mode are defined in `docs/.vitepress/theme/style.css` — **do not write `classDef` or `style X fill:` lines in diagram source**. Use only `class` assignment statements. Every node must be assigned one of these five classes.
 
-| Class name | Color   | Semantic use                                        |
-|------------|---------|-----------------------------------------------------|
-| `decision` | blue    | conditional branches, diamond nodes                 |
-| `input`    | yellow  | triggers, external sources                          |
-| `process`  | gray    | intermediate work, retries                          |
-| `output`   | green   | successful terminal states, published artefacts     |
-| `neutral`  | violet  | sequential steps with no special semantic role      |
+| Class name | Semantic use                                        |
+|------------|-----------------------------------------------------|
+| `decision` | conditional branches, diamond nodes                 |
+| `input`    | triggers, external sources                          |
+| `process`  | intermediate work, retries                          |
+| `output`   | successful terminal states, published artefacts     |
+| `neutral`  | sequential steps with no special semantic role      |
 
 **Example:**
 

--- a/docs/contributing/documentation/vitepress-features.md
+++ b/docs/contributing/documentation/vitepress-features.md
@@ -194,6 +194,31 @@ flowchart TD
 **Real-world example:**
 See the [Maintained Releases](/reference/releases/maintained-releases) page for a complete Gantt chart showing release maintenance phases.
 
+## Theme-Adaptive Images
+
+Some diagrams and illustrations need different versions for light and dark mode — for example, SVGs with dark strokes that are invisible on a dark background.
+
+Append `#light-mode-only` or `#dark-mode-only` to the image path. The VitePress theme CSS hides the wrong variant automatically.
+
+**Syntax:**
+
+```markdown
+![Description of the image](image-light.svg#light-mode-only)
+![Description of the image](image-dark.svg#dark-mode-only)
+```
+
+Both lines must use identical alt text so screen readers and search engines see a single logical image.
+
+**When to use:**
+
+- SVG diagrams with strokes or text that rely on a white or black background
+- Any image where contrast or legibility differs significantly between themes
+
+**Naming convention:** suffix the dark variant's filename with `_dark` before the extension (e.g. `diagram.svg` / `diagram_dark.svg`). Keep both files in the same `.media/` directory as the page.
+
+**Real-world example:**
+See [Boot Modes](/explanation/boot-modes) for SVG diagrams that use both variants.
+
 ## Container Syntax (Callouts)
 
 VitePress supports special container blocks for callouts and highlighted content. Garden Linux documentation uses these throughout.

--- a/docs/contributing/documentation/vitepress-features.md
+++ b/docs/contributing/documentation/vitepress-features.md
@@ -133,7 +133,7 @@ Garden Linux documentation supports [Mermaid](https://mermaid.js.org/) diagrams 
 - Displaying complex relationships
 
 **How it works:**
-The plugin automatically renders code blocks marked with `mermaid` as diagrams. It includes custom theming that matches the Garden Linux brand colors (green scheme) and supports dark mode.
+The plugin automatically renders code blocks marked with `mermaid` as diagrams. It supports dark mode and injects a shared set of semantic class definitions into every diagram at build time.
 
 **Syntax:**
 
@@ -161,23 +161,35 @@ gantt
 ```
 ````
 
-**Custom theming:**
-The documentation uses a green color scheme matching Garden Linux branding:
+### Mermaid styling
 
+Flowchart nodes are styled using five canonical semantic class names. The VitePress build injects their color definitions automatically — **do not write `classDef` or `style X fill:` lines in diagram source**. Use only `class` assignment statements. Every node must be assigned one of these five classes.
+
+| Class name | Color   | Semantic use                                        |
+|------------|---------|-----------------------------------------------------|
+| `decision` | blue    | conditional branches, diamond nodes                 |
+| `input`    | yellow  | triggers, external sources                          |
+| `process`  | gray    | intermediate work, retries                          |
+| `output`   | green   | successful terminal states, published artefacts     |
+| `neutral`  | violet  | sequential steps with no special semantic role      |
+
+**Example:**
+
+````markdown
 ```mermaid
-%%{init: {'theme':'base', 'themeVariables': {
-  'primaryColor':'#30a46c',
-  'primaryTextColor':'#fff',
-  'primaryBorderColor':'#18794e',
-  'lineColor':'#30a46c',
-  'textColor':'#009f76'
-}}}%%
-gantt
-    title Theme Preview
-    dateFormat YYYY-MM-DD
-    section Example
-    Task 1 :2024-01-01, 10d
+flowchart TD
+    Boot[Power On] --> Check{Feature present?}
+    Check -->|Yes| Install[Install to disk]
+    Check -->|No| Live[Live boot only]
+    Install --> Done[System running]
+
+    class Boot neutral
+    class Check decision
+    class Install output
+    class Live process
+    class Done neutral
 ```
+````
 
 **Real-world example:**
 See the [Maintained Releases](/reference/releases/maintained-releases) page for a complete Gantt chart showing release maintenance phases.
@@ -301,7 +313,9 @@ Branch name for edit links.
 - Use for timelines, processes, and complex relationships
 - Keep diagrams simple and focused
 - Test in both light and dark mode (use the preview)
-- Don't overuse - diagrams should add clarity, not replace text
+- Don't overuse — diagrams should add clarity, not replace text
+- Use the five canonical class names (`decision`, `input`, `process`, `output`, `neutral`) for node colors — every node must be assigned one
+- Do not write `classDef` declarations or `style X fill:` lines in diagram source
 
 ### Containers/Callouts
 

--- a/repos-config.json
+++ b/repos-config.json
@@ -4,7 +4,7 @@
       "name": "gardenlinux",
       "url": "https://github.com/gardenlinux/gardenlinux",
       "ref": "docs-ng",
-      "commit": "b6ea9704d22871d1893a9e4567f43eca94201d52",
+      "commit": "e982815ba31e79c9f6606e27ede1590e3b634163",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",
@@ -46,7 +46,7 @@
       "name": "repo",
       "url": "https://github.com/gardenlinux/repo",
       "ref": "docs-ng",
-      "commit": "9adfc48e8933c6f6a66f00bbfb28756259d04aa1"
+      "commit": "030acbd0d9c08da047e65f8becd28862aefecd17"
     },
     {
       "name": "glrd",


### PR DESCRIPTION
**What this PR does / why we need it**:

- docs: add mermaid-classdefs plugin, canonical classes, and dark-mode color support
  - Add a markdown-it plugin (`docs/.vitepress/plugins/mermaid-classdefs.ts`) that injects five shared `classDef` declarations into every flowchart/graph mermaid fence at build time, eliminating per-diagram hex color duplication. Skips `sequenceDiagram`, `gantt`, and `%%{init}%%` blocks where `classDef` is invalid syntax.
  - Five canonical semantic classes: `decision`, `input`, `process`, `output`, `neutral` — assigned by authors with `class NodeA decision`; never written as `classDef` or `style X fill:` directly in diagram source.
  - Move all color values out of the plugin and into `docs/.vitepress/theme/style.css`. The plugin emits only `opacity:1` per class (a visually inert sentinel that registers the class name with mermaid without causing mermaid to emit competing `!important` fill/stroke rules).
  - Add light-mode and dark-mode palettes to `theme/style.css`. Declarations use `!important` to override mermaid's SVG-scoped theme CSS, which is injected with ID-selector specificity (`#mermaid-N .node rect { fill: ... }`) and would otherwise take precedence over plain class selectors. Dark-mode fills are deep-tinted versions of the light-mode hues with bright colored strokes and light text; node colors switch automatically when the reader toggles the site theme.
  - Update `vitepress-features.md` to document the five canonica

### before

<img width="719" height="634" alt="image" src="https://github.com/user-attachments/assets/cdbe1edd-1c0f-49fb-bdae-67b893ebef25" />

<img width="729" height="638" alt="image" src="https://github.com/user-attachments/assets/38e1ec24-935a-4cda-9f0f-2f3b4f9436ea" />


### after

<img width="717" height="644" alt="image" src="https://github.com/user-attachments/assets/d9b4a0a2-ab13-4d1e-a641-ee50147122c5" />

<img width="728" height="635" alt="image" src="https://github.com/user-attachments/assets/56937c38-da64-452a-a675-e5467b11ca1c" />


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/4972
Fixes https://github.com/gardenlinux/gardenlinux/issues/4971
