### PR TITLE
feat: add _redirects

### DIFF
--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,4 @@
+http://gardenlinux.org/*      https://docs.gardenlinux.org/:splat  301!
+https://gardenlinux.org/*     https://docs.gardenlinux.org/:splat  301!
+http://www.gardenlinux.org/*  https://docs.gardenlinux.org/:splat  301!
+https://www.gardenlinux.org/* https://docs.gardenlinux.org/:splat  301!

--- a/repos-config.json
+++ b/repos-config.json
@@ -4,7 +4,7 @@
       "name": "gardenlinux",
       "url": "https://github.com/gardenlinux/gardenlinux",
       "ref": "docs-ng",
-      "commit": "e982815ba31e79c9f6606e27ede1590e3b634163",
+      "commit": "037000ff0cdadf6c0c19a5db21b26195f6d19412",
       "root_files": [
         "CONTRIBUTING.md",
         "SECURITY.md",


### PR DESCRIPTION
**What this PR does / why we need it**:

feat: add _redirects

Redirect (www.|)gardenlinux.org to the documentation page