### PR TITLE
Fix: Fix 404 errors in Footer by linking to linuxfoundation.eu

### DIFF
--- a/docs/.vitepress/theme/components/VPFooter.vue
+++ b/docs/.vitepress/theme/components/VPFooter.vue
@@ -118,15 +118,6 @@ const projectName = title || "Garden Linux";
           </a>
         </div>
       </div>
-
-      <!-- Row 3: Legal links (always last) -->
-      <div class="footer-legal-links">
-        <a href="/about/terms-of-use">Terms of Use</a>
-        <span class="footer-legal-sep">|</span>
-        <a href="/about/privacy">Privacy Statement</a>
-        <span class="footer-legal-sep">|</span>
-        <a href="/about/legal-disclosure">Legal Disclosure</a>
-      </div>
     </div>
   </footer>
 </template>


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the 404 errors when clicking on any of the legal links in the website's footer by linking to the appropriate pages of linuxfoundation.eu.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardenlinux/gardenlinux/issues/5108

**Definition of Done:**
- [x] The code is sufficiently documented
- [x] Shared the changes with the Team so everyone is aware
- [x] The code is appropriately tested
- [x] Checked if the code needs to be backportet to release branches of maintained versions (perform the actual backport after the merge to `main`)