### PR TITLE
Docs: Enroll nvidia-installer-docs

### DIFF
--- a/repos-config.json
+++ b/repos-config.json
@@ -53,6 +53,12 @@
       "url": "https://github.com/gardenlinux/glrd",
       "ref": "main",
       "commit": "d24a4d63107fdba44531faf831668a26c7ca20a2"
+    },
+    {
+      "name": "gardenlinux-nvidia-installer",
+      "url": "https://github.com/gardenlinux/gardenlinux-nvidia-installer",
+      "ref": "main",
+      "commit": "bb773a56b4a39d067232b10adf245ee4761c3489"
     }
   ]
 }

--- a/repos-config.local.json
+++ b/repos-config.local.json
@@ -39,6 +39,10 @@
     {
       "name": "glrd",
       "url": "file://../glrd"
+    },
+    {
+      "name": "gardenlinux-nvidia-installer",
+      "url": "file://../gardenlinux-nvidia-installer"
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Enrolls NVIDIA Installer Docs.